### PR TITLE
Define cirq.PAULI_GATE_LIKE (#2557)

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -219,6 +219,7 @@ from cirq.ops import (
     Operation,
     ParallelGateOperation,
     Pauli,
+    PAULI_GATE_LIKE,
     PAULI_STRING_LIKE,
     PauliInteractionGate,
     PauliString,

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -172,6 +172,7 @@ from cirq.ops.pauli_interaction_gate import (
     PauliInteractionGate,)
 
 from cirq.ops.pauli_string import (
+    PAULI_GATE_LIKE,
     PAULI_STRING_LIKE,
     PauliString,
     SingleQubitPauliStringGateOperation,

--- a/cirq/ops/dense_pauli_string.py
+++ b/cirq/ops/dense_pauli_string.py
@@ -49,10 +49,11 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
     Y_VAL = 2
     Z_VAL = 3
 
-    def __init__(self,
-                 pauli_mask: Union[str, Iterable[int], np.ndarray],
-                 *,
-                 coefficient: Union[sympy.Basic, int, float, complex] = 1):
+    def __init__(
+            self,
+            pauli_mask: Union[Iterable['cirq.PAULI_GATE_LIKE'], np.ndarray],
+            *,
+            coefficient: Union[sympy.Basic, int, float, complex] = 1):
         """Initializes a new dense pauli string.
 
         Args:
@@ -94,14 +95,15 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
 
     @classmethod
     def one_hot(cls: Type[TCls], *, index: int, length: int,
-                pauli: Union[str, 'cirq.Gate']) -> TCls:
+                pauli: 'cirq.PAULI_GATE_LIKE') -> TCls:
         """Creates a dense pauli string with only one non-identity Pauli.
 
         Args:
             index: The index of the Pauli that is not an identity.
             pauli: The pauli gate to put at the hot index. Can be set to either
-                a string ('X', 'Y', 'Z', 'I') or a cirq gate (`cirq.X`,
-                `cirq.Y`, `cirq.Z`, or `cirq.I`).
+                a string ('X', 'Y', 'Z', 'I'), a cirq gate (`cirq.X`,
+                `cirq.Y`, `cirq.Z`, or `cirq.I`), or an integer (0=I, 1=X, 2=Y,
+                3=Z).
         """
         mask = np.zeros(length, dtype=np.uint8)
         mask[index] = _pauli_index(pauli)
@@ -477,38 +479,21 @@ class MutableDensePauliString(BaseDensePauliString):
                 next_row += 1
 
 
-def _pauli_index(val: Any):
-    if isinstance(val, str):
-        return PAULI_CHARS.index(val)
-    if isinstance(val, raw_types.Gate):
-        return PAULI_GATES.index(val)
-    if isinstance(val, int) and 0 <= val < 4:
-        return val
-    raise TypeError(f'Expected a Pauli character (IXYZ), gate, or index but '
-                    f'got {repr(val)}.')
+def _pauli_index(val: 'cirq.PAULI_GATE_LIKE') -> int:
+    m = pauli_string.PAULI_GATE_LIKE_TO_INDEX_MAP
+    if val not in m:
+        raise TypeError(
+            f'Expected a cirq.PAULI_GATE_LIKE (any of cirq.I cirq.X, cirq.Y, '
+            f'cirq.Z, "I", "X", "Y", "Z", "i", "x", "y", "z", 0, 1, 2, 3) but '
+            f'got {repr(val)}.')
+    return m[val]
 
 
-def _as_pauli_mask(val: Union[str, Iterable[int], np.ndarray]) -> np.ndarray:
+def _as_pauli_mask(val: Union[Iterable['cirq.PAULI_GATE_LIKE'], np.ndarray]
+                  ) -> np.ndarray:
     if isinstance(val, np.ndarray):
         return np.asarray(val, dtype=np.uint8)
-
-    if isinstance(val, str):
-        return _str_to_pauli_mask(val)
-
     return np.array([_pauli_index(v) for v in val], dtype=np.uint8)
-
-
-def _str_to_pauli_mask(text: str) -> np.ndarray:
-    result = np.zeros(len(text), dtype=np.uint8)
-    for i in range(len(text)):
-        c = text[i]
-        try:
-            result[i] = PAULI_CHARS.index(c)
-        except ValueError:
-            raise ValueError(
-                f'Not a Pauli character: {repr(c)}. Valid Pauli characters are '
-                f'upper case IXYZ.\ntext={repr(text)}.')
-    return result
 
 
 def _attempt_value_to_pauli_index(v: Any) -> Optional[Tuple[int, int]]:
@@ -525,7 +510,7 @@ def _attempt_value_to_pauli_index(v: Any) -> Optional[Tuple[int, int]]:
             'Got a Pauli operation, but it was applied to a qubit type '
             'other than `cirq.LineQubit` so its dense index is ambiguous.\n'
             f'v={repr(v)}.')
-    return PAULI_GATES.index(v.gate), q.x
+    return pauli_string.PAULI_GATE_LIKE_TO_INDEX_MAP[v.gate], q.x
 
 
 def _vectorized_pauli_mul_phase(lhs: Union[int, np.ndarray],

--- a/cirq/ops/dense_pauli_string_test.py
+++ b/cirq/ops/dense_pauli_string_test.py
@@ -47,7 +47,7 @@ def test_init():
     # Mixed types.
     assert cirq.DensePauliString([1, 'X',
                                   cirq.X]) == cirq.DensePauliString('XXX')
-    with pytest.raises(TypeError, match='Expected a Pauli'):
+    with pytest.raises(TypeError, match='Expected a cirq.PAULI_GATE_LIKE'):
         _ = cirq.DensePauliString([object()])
 
 
@@ -79,7 +79,9 @@ def test_from_text():
     assert d('XYZI') == d([1, 2, 3, 0])
     assert d('III', coefficient=-1) == d([0, 0, 0], coefficient=-1)
     assert d('XXY', coefficient=1j) == d([1, 1, 2], coefficient=1j)
-    with pytest.raises(ValueError, match='Not a Pauli character'):
+    assert d('ixyz') == d([0, 1, 2, 3])
+    assert d(['i', 'x', 'y', 'z']) == d([0, 1, 2, 3])
+    with pytest.raises(TypeError, match='Expected a cirq.PAULI_GATE_LIKE'):
         _ = d('2')
 
 

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -1388,6 +1388,13 @@ def test_conjugated_by_common_single_qubit_gates():
     a, b = cirq.LineQubit.range(2)
 
     base_single_qubit_gates = [
+        cirq.I,
+        cirq.X,
+        cirq.Y,
+        cirq.Z,
+        cirq.X**-0.5,
+        cirq.Y**-0.5,
+        cirq.Z**-0.5,
         cirq.X**0.5,
         cirq.Y**0.5,
         cirq.Z**0.5,
@@ -1421,13 +1428,19 @@ def test_conjugated_by_common_two_qubit_gates():
         cirq.CNOT,
         cirq.CZ,
         cirq.ISWAP,
+        cirq.ISWAP**-1,
         cirq.SWAP,
         cirq.XX**0.5,
         cirq.YY**0.5,
         cirq.ZZ**0.5,
+        cirq.XX**-0.5,
+        cirq.YY**-0.5,
+        cirq.ZZ**-0.5,
     ]
     two_qubit_gates = [g**i for i in range(4) for g in base_two_qubit_gates]
-    two_qubit_gates.append(OrderSensitiveGate())
+    two_qubit_gates.extend([
+        OrderSensitiveGate(),
+    ])
     for p1 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
         for p2 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
             for g in two_qubit_gates:
@@ -1498,3 +1511,26 @@ def test_pass_operations_over_ordering_reversed():
                                     after_to_before=True).pass_operations_over(
                                         [cirq.CNOT(a, b)], after_to_before=True)
     assert out1 == out2 == out3 == cirq.Z(b)
+
+
+def test_pretty_print():
+    a, b, c = cirq.LineQubit.range(3)
+    result = cirq.PauliString({a: 'x', b: 'y', c: 'z'})
+
+    # Test Jupyter console output from
+    class FakePrinter:
+
+        def __init__(self):
+            self.text_pretty = ''
+
+        def text(self, to_print):
+            self.text_pretty += to_print
+
+    p = FakePrinter()
+    result._repr_pretty_(p, False)
+    assert p.text_pretty == 'X(0)*Y(1)*Z(2)'
+
+    # Test cycle handling
+    p = FakePrinter()
+    result._repr_pretty_(p, True)
+    assert p.text_pretty == 'cirq.PauliString(...)'

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -186,6 +186,7 @@ SHOULDNT_BE_SERIALIZED = [
     'DURATION_LIKE',
     'NOISE_MODEL_LIKE',
     'OP_TREE',
+    'PAULI_GATE_LIKE',
     'PAULI_STRING_LIKE',
     'ParamResolverOrSimilarType',
     'PauliSumLike',

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,6 +146,7 @@ and products of Pauli operations.
     :toctree: generated/
 
     cirq.PAULI_BASIS
+    cirq.PAULI_GATE_LIKE
     cirq.PAULI_STRING_LIKE
     cirq.pow_pauli_combination
     cirq.BaseDensePauliString


### PR DESCRIPTION
- Use in `cirq.PauliString` and `cirq.DensePauliString`
- Generalize to allow lower case "ixyz"
- Make it consistent to allow integers 0=I, 1=X, 2=Y, 3=Z

Example:

```python
cirq.PauliString({
    cirq.GridQubit(0, 0): 0,
    cirq.GridQubit(0, 1): 1,
    cirq.GridQubit(0, 2): 2,
    cirq.GridQubit(0, 3): 3,
})
```

```
X((0, 1))*Y((0, 2))*Z((0, 3))
```